### PR TITLE
feat(tmdb): support getting languages

### DIFF
--- a/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/controller/v1/ConfigurationController.java
+++ b/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/controller/v1/ConfigurationController.java
@@ -1,0 +1,26 @@
+package com.nextepisode.tmdb_service.controller.v1;
+
+import com.nextepisode.tmdb_service.config.ApiPaths;
+import com.nextepisode.tmdb_service.dto.configuration.TMDBLanguageListResponse;
+import com.nextepisode.tmdb_service.service.TMDBConfigurationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping(ApiPaths.API_V1 + "/configuration")
+@RestController
+public class ConfigurationController {
+
+    private final TMDBConfigurationService tmdbConfigurationService;
+
+    public ConfigurationController(TMDBConfigurationService tmdbConfigurationService) {
+        this.tmdbConfigurationService = tmdbConfigurationService;
+    }
+
+    @GetMapping("/languages")
+    public TMDBLanguageListResponse moviesGenres() {
+        return tmdbConfigurationService.getLanguages();
+    }
+}

--- a/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/dto/configuration/TMDBLanguage.java
+++ b/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/dto/configuration/TMDBLanguage.java
@@ -1,0 +1,19 @@
+package com.nextepisode.tmdb_service.dto.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TMDBLanguage {
+
+    @JsonProperty("iso_639_1")
+    public String isoNationalCode;
+    @JsonProperty("english_name")
+    public String englishName;
+    @JsonProperty("name")
+    public String name;
+
+
+}

--- a/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/dto/configuration/TMDBLanguageListResponse.java
+++ b/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/dto/configuration/TMDBLanguageListResponse.java
@@ -1,0 +1,23 @@
+package com.nextepisode.tmdb_service.dto.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Builder
+public class TMDBLanguageListResponse {
+
+    @Builder.Default
+    public Integer total = 0;
+
+    @Builder.Default
+    public Instant storedAt = Instant.now();
+
+    @JsonProperty("languages")
+    public List<TMDBLanguage> languages;
+
+}

--- a/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/service/TMDBConfigurationService.java
+++ b/backend/tmdb-service/src/main/java/com/nextepisode/tmdb_service/service/TMDBConfigurationService.java
@@ -1,0 +1,45 @@
+package com.nextepisode.tmdb_service.service;
+
+
+import com.nextepisode.tmdb_service.config.CacheConfig;
+import com.nextepisode.tmdb_service.dto.configuration.TMDBLanguage;
+import com.nextepisode.tmdb_service.dto.configuration.TMDBLanguageListResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class TMDBConfigurationService extends BaseService {
+
+
+    public TMDBConfigurationService(RestClient TMDBClient) {
+        super(TMDBClient);
+    }
+
+
+    @Cacheable(CacheConfig.TMDB_API_LANGUAGES)
+    public TMDBLanguageListResponse getLanguages() {
+        log.info("Start getting tmdb api languages");
+        try {
+            List<TMDBLanguage> languages = TMDBClient.get().uri(uriBuilder -> uriBuilder
+                    .path("/configuration/languages")
+                    .queryParam("language", "en-US")
+                    .build()).retrieve().body(new ParameterizedTypeReference<List<TMDBLanguage>>() {
+                                              }
+            );
+
+            return TMDBLanguageListResponse.builder().languages(languages).total(languages.size()).build();
+
+        } catch (Exception e) {
+            log.error("Failed to get languages: ", e);
+            throw new RuntimeException("Failed to get languages: ", e);
+        }
+    }
+
+
+}


### PR DESCRIPTION
- add languages dto and lst
- add configuration(languages belongs to the configuration category) service
- add configuration controller
- add /configuration/languages endpoint